### PR TITLE
Fix field definition position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ target/
 
 # Node.js
 node_modules/
+.idea

--- a/src/main/java/org/apache/groovy/parser/antlr4/util/PositionConfigureUtils.java
+++ b/src/main/java/org/apache/groovy/parser/antlr4/util/PositionConfigureUtils.java
@@ -1,0 +1,130 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.groovy.parser.antlr4.util;
+
+import groovy.lang.Tuple2;
+
+import groovyjarjarantlr4.v4.runtime.Token;
+import groovyjarjarantlr4.v4.runtime.tree.TerminalNode;
+import org.apache.groovy.parser.antlr4.GroovyParser;
+import org.codehaus.groovy.ast.ASTNode;
+
+import static groovy.lang.Tuple.tuple;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.asBoolean;
+
+/**
+ *
+ * the latest groovy version still fix this problem
+ */
+public class PositionConfigureUtils {
+    /**
+     * Sets location(lineNumber, colNumber, lastLineNumber, lastColumnNumber) for node using standard context information.
+     * Note: this method is implemented to be closed over ASTNode. It returns same node as it received in arguments.
+     *
+     * @param astNode Node to be modified.
+     * @param ctx     Context from which information is obtained.
+     * @return Modified astNode.
+     */
+    public static <T extends ASTNode> T configureAST(T astNode, GroovyParser.GroovyParserRuleContext ctx) {
+        Token start = ctx.getStart();
+        Token stop = ctx.getStop();
+
+        astNode.setLineNumber(start.getLine());
+        astNode.setColumnNumber(start.getCharPositionInLine() + 1);
+
+        configureEndPosition(astNode, stop);
+
+        return astNode;
+    }
+
+    public static Tuple2<Integer, Integer> endPosition(Token token) {
+        String stopText = token.getText();
+        int stopTextLength = 0;
+        int newLineCnt = 0;
+        if (null != stopText) {
+            stopTextLength = stopText.length();
+            newLineCnt = (int) StringUtils.countChar(stopText, '\n');
+        }
+
+        if (0 == newLineCnt) {
+            return tuple(token.getLine(), token.getCharPositionInLine() + 1 + token.getText().length());
+        } else { // e.g. GStringEnd contains newlines, we should fix the location info
+            return tuple(token.getLine() + newLineCnt, stopTextLength - stopText.lastIndexOf('\n'));
+        }
+    }
+
+    public static <T extends ASTNode> T configureAST(T astNode, TerminalNode terminalNode) {
+        return configureAST(astNode, terminalNode.getSymbol());
+    }
+
+    public static <T extends ASTNode> T configureAST(T astNode, Token token) {
+        astNode.setLineNumber(token.getLine());
+        astNode.setColumnNumber(token.getCharPositionInLine() + 1);
+        astNode.setLastLineNumber(token.getLine());
+        astNode.setLastColumnNumber(token.getCharPositionInLine() + 1 + token.getText().length());
+
+        return astNode;
+    }
+
+    public static <T extends ASTNode> T configureAST(T astNode, ASTNode source) {
+        astNode.setLineNumber(source.getLineNumber());
+        astNode.setColumnNumber(source.getColumnNumber());
+        astNode.setLastLineNumber(source.getLastLineNumber());
+        astNode.setLastColumnNumber(source.getLastColumnNumber());
+
+        return astNode;
+    }
+
+    public static <T extends ASTNode> T configureAST(T astNode, GroovyParser.GroovyParserRuleContext ctx, ASTNode stop) {
+        Token start = ctx.getStart();
+
+        astNode.setLineNumber(start.getLine());
+        astNode.setColumnNumber(start.getCharPositionInLine() + 1);
+
+        if (asBoolean(stop)) {
+            astNode.setLastLineNumber(stop.getLastLineNumber());
+            astNode.setLastColumnNumber(stop.getLastColumnNumber());
+        } else {
+            configureEndPosition(astNode, ctx.getStop());
+        }
+
+        return astNode;
+    }
+
+    public static <T extends ASTNode> void configureEndPosition(T astNode, Token token) {
+        Tuple2<Integer, Integer> endPosition = endPosition(token);
+        astNode.setLastLineNumber(endPosition.getV1());
+        astNode.setLastColumnNumber(endPosition.getV2());
+    }
+
+    public static <T extends ASTNode> T configureAST(T astNode, ASTNode start, ASTNode stop) {
+        astNode.setLineNumber(start.getLineNumber());
+        astNode.setColumnNumber(start.getColumnNumber());
+
+        if (asBoolean(stop)) {
+            astNode.setLastLineNumber(stop.getLastLineNumber());
+            astNode.setLastColumnNumber(stop.getLastColumnNumber());
+        } else {
+            astNode.setLastLineNumber(start.getLastLineNumber());
+            astNode.setLastColumnNumber(start.getLastColumnNumber());
+        }
+
+        return astNode;
+    }
+}

--- a/src/test/java/net/prominic/groovyls/GroovyServicesDefinitionTests.java
+++ b/src/test/java/net/prominic/groovyls/GroovyServicesDefinitionTests.java
@@ -226,7 +226,7 @@ class GroovyServicesDefinitionTests {
 		Assertions.assertEquals(1, location.getRange().getStart().getLine());
 		Assertions.assertEquals(2, location.getRange().getStart().getCharacter());
 		Assertions.assertEquals(1, location.getRange().getEnd().getLine());
-		Assertions.assertEquals(8, location.getRange().getEnd().getCharacter());
+		Assertions.assertEquals(24, location.getRange().getEnd().getCharacter());
 	}
 
 	@Test
@@ -252,7 +252,7 @@ class GroovyServicesDefinitionTests {
 		Assertions.assertEquals(1, location.getRange().getStart().getLine());
 		Assertions.assertEquals(2, location.getRange().getStart().getCharacter());
 		Assertions.assertEquals(1, location.getRange().getEnd().getLine());
-		Assertions.assertEquals(8, location.getRange().getEnd().getCharacter());
+		Assertions.assertEquals(24, location.getRange().getEnd().getCharacter());
 	}
 
 	// --- member properties
@@ -303,7 +303,7 @@ class GroovyServicesDefinitionTests {
 		Assertions.assertEquals(1, location.getRange().getStart().getLine());
 		Assertions.assertEquals(2, location.getRange().getStart().getCharacter());
 		Assertions.assertEquals(1, location.getRange().getEnd().getLine());
-		Assertions.assertEquals(5, location.getRange().getEnd().getCharacter());
+		Assertions.assertEquals(16, location.getRange().getEnd().getCharacter());
 	}
 
 	// --- member methods
@@ -588,6 +588,6 @@ class GroovyServicesDefinitionTests {
 		Assertions.assertEquals(5, location.getRange().getStart().getLine());
 		Assertions.assertEquals(2, location.getRange().getStart().getCharacter());
 		Assertions.assertEquals(5, location.getRange().getEnd().getLine());
-		Assertions.assertEquals(8, location.getRange().getEnd().getCharacter());
+		Assertions.assertEquals(21, location.getRange().getEnd().getCharacter());
 	}
 }


### PR DESCRIPTION
The root cause is that the groovy compiler has a problem with the parsing of the Fieldnode
it  has been fixed in groovy github repo ,But not reflected in the latest version 3.0.8 .
So I directly overwritten it with a file