### PR TITLE
Show GroovyDoc comments on hover

### DIFF
--- a/src/main/java/net/prominic/groovyls/config/CompilationUnitFactory.java
+++ b/src/main/java/net/prominic/groovyls/config/CompilationUnitFactory.java
@@ -26,7 +26,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.codehaus.groovy.control.CompilerConfiguration;
@@ -105,6 +107,11 @@ public class CompilationUnitFactory implements ICompilationUnitFactory {
 
 	protected CompilerConfiguration getConfiguration() {
 		CompilerConfiguration config = new CompilerConfiguration();
+
+		Map<String, Boolean> options = new HashMap<String, Boolean>();
+		options.put(CompilerConfiguration.GROOVYDOC, true);
+
+		config.setOptimizationOptions(options);
 
 		List<String> classpathList = new ArrayList<>();
 		getClasspathList(classpathList);

--- a/src/main/java/net/prominic/groovyls/util/GroovyDocUtils.java
+++ b/src/main/java/net/prominic/groovyls/util/GroovyDocUtils.java
@@ -1,0 +1,188 @@
+package net.prominic.groovyls.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import groovy.lang.groovydoc.Groovydoc;
+
+import org.codehaus.groovy.ast.AnnotatedNode;
+
+/**
+ * Functions for retrieving and formatting GroovyDoc strings.
+ */
+public class GroovyDocUtils {
+
+  /**
+   * Gets the docString for a node and converts it to markdown. If the node
+   * doesn't have a docString then null is returned.
+   * 
+   * @param node The AST node to check for a docString.
+   * @return The converted docString or null.
+   */
+  public static String getDocString(AnnotatedNode node) {
+
+    Groovydoc docstring = node.getGroovydoc();
+    String content = null;
+
+    if (docstring.isPresent()) {
+      content = convertToMarkdown(docstring.getContent());
+    }
+
+    return content;
+  }
+
+  /**
+   * Converts a docString into Markdown. The comment markers will be removed.
+   * Parameters and the return value will be turned into a bullet list. All other
+   * tags will be removed. HTML will be left untouched but will likely be stripped
+   * by the LS client.
+   * 
+   * @param text The text you want to convert.
+   * @return The text converted to Markdown.
+   */
+  public static String convertToMarkdown(String text) {
+
+    String result;
+
+    result = removeComment(text);
+
+    result = convertParams(result);
+
+    result = convertReturn(result);
+
+    result = removeTags(result);
+
+    result = convertNewLines(result);
+
+    return result;
+
+  }
+
+  /**
+   * Takes a commented block of text and removes the comment, leaving the content
+   * as is.
+   * 
+   * @param text The commented block of text.
+   * @return The content from inside the comment block.
+   */
+  public static String removeComment(String text) {
+
+    String result;
+    Pattern pattern;
+    Matcher matcher;
+
+    // Get the content from "* some content\n" to "some content\n"
+    final String content = "^[\\h]*\\*\\h?(.*\\n)";
+    final String cSubst = "$1";
+
+    pattern = Pattern.compile(content, Pattern.MULTILINE);
+    matcher = pattern.matcher(text);
+
+    result = matcher.replaceAll(cSubst);
+
+    // Strips the leading comment "/**""
+    final String stripLeading = "^\\h?\\/\\*{2}\\s*";
+    final String lSubst = "";
+
+    pattern = Pattern.compile(stripLeading, Pattern.MULTILINE);
+    matcher = pattern.matcher(result);
+
+    result = matcher.replaceAll(lSubst);
+
+    // Strips the trailing comment "\*"
+    final String stripTrailing = "\\h?\\*\\/\\s?$";
+    final String tSubst = "";
+
+    pattern = Pattern.compile(stripTrailing, Pattern.MULTILINE);
+    matcher = pattern.matcher(result);
+
+    result = matcher.replaceAll(tSubst);
+
+    return result;
+
+  }
+
+  /**
+   * Converts GroovyDoc param tags to Markdown bullet list. If no tags are found
+   * then the original text is returned.
+   * 
+   * @param text The docString to convert.
+   * @return The text with param tags converted to Markdown bullet list.
+   */
+  protected static String convertParams(String text) {
+    final String regex = "^\\h*\\@(param)\\h+(\\w*)\\h+(.*)$";
+
+    final String subst = "- *$1* **$2** - $3";
+
+    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+    final Matcher matcher = pattern.matcher(text);
+
+    final String result = matcher.replaceAll(subst);
+
+    return result;
+  }
+
+  /**
+   * Converts GroovyDoc return tag to Markdown bullet list. If no return tag is
+   * found then the original text is returned.
+   * 
+   * @param text The docString to convert.
+   * @return The text with return tag converted to Markdown bullet list.
+   */
+  protected static String convertReturn(String text) {
+    final String regex = "^\\h*\\@(return)\\h+(.*)$";
+
+    final String subst = "- *$1* - $2";
+
+    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+    final Matcher matcher = pattern.matcher(text);
+
+    final String result = matcher.replaceAll(subst);
+
+    return result;
+
+  }
+
+  /**
+   * Removes all GroovyDoc tags from a string. If no tags are found then the
+   * original text is returned.
+   * 
+   * @param text The docString to convert.
+   * @return The text with all GroovyDoc tags removed.
+   */
+  protected static String removeTags(String text) {
+    final String regex = "^\\h?\\@.*\\n?";
+
+    final String subst = "";
+
+    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+    final Matcher matcher = pattern.matcher(text);
+
+    // The substituted value will be contained in the result variable
+    final String result = matcher.replaceAll(subst);
+
+    return result;
+  }
+
+  /**
+   * Converts \n lines into Markdown newlines by prepending two spaces like " \n"
+   * 
+   * @param text The docString to convert.
+   * @return The text with Markdown newlines.
+   */
+  protected static String convertNewLines(String text) {
+
+    final String regex = "\\n";
+
+    final String subst = "  \n";
+
+    final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+    final Matcher matcher = pattern.matcher(text);
+
+    final String result = matcher.replaceAll(subst);
+
+    return result;
+
+  }
+
+}

--- a/src/main/java/net/prominic/groovyls/util/GroovyNodeToStringUtils.java
+++ b/src/main/java/net/prominic/groovyls/util/GroovyNodeToStringUtils.java
@@ -20,6 +20,7 @@
 package net.prominic.groovyls.util;
 
 import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.ConstructorNode;
 import org.codehaus.groovy.ast.FieldNode;
@@ -27,6 +28,7 @@ import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.Variable;
 
+import groovy.lang.groovydoc.Groovydoc;
 import net.prominic.groovyls.compiler.ast.ASTNodeVisitor;
 import net.prominic.groovyls.compiler.util.GroovyASTUtils;
 
@@ -66,6 +68,9 @@ public class GroovyNodeToStringUtils {
 			builder.append(" extends ");
 			builder.append(superClass.getNameWithoutPackage());
 		}
+
+		addDocString(classNode, builder);
+
 		return builder.toString();
 	}
 
@@ -75,6 +80,9 @@ public class GroovyNodeToStringUtils {
 		builder.append("(");
 		builder.append(parametersToString(constructorNode.getParameters(), ast));
 		builder.append(")");
+
+		addDocString(constructorNode, builder);
+
 		return builder.toString();
 	}
 
@@ -107,6 +115,9 @@ public class GroovyNodeToStringUtils {
 		builder.append("(");
 		builder.append(parametersToString(methodNode.getParameters(), ast));
 		builder.append(")");
+
+		addDocString(methodNode, builder);
+
 		return builder.toString();
 	}
 
@@ -154,5 +165,15 @@ public class GroovyNodeToStringUtils {
 		builder.append(" ");
 		builder.append(variable.getName());
 		return builder.toString();
+	}
+
+	public static void addDocString(AnnotatedNode node, StringBuilder builder) {
+
+		Groovydoc docstring = node.getGroovydoc();
+
+		if(docstring.isPresent()) {
+			builder.append("\n");
+			builder.append(docstring.getContent());
+		}
 	}
 }

--- a/src/main/java/net/prominic/groovyls/util/GroovyNodeToStringUtils.java
+++ b/src/main/java/net/prominic/groovyls/util/GroovyNodeToStringUtils.java
@@ -20,7 +20,6 @@
 package net.prominic.groovyls.util;
 
 import org.codehaus.groovy.ast.ASTNode;
-import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.ConstructorNode;
 import org.codehaus.groovy.ast.FieldNode;
@@ -28,7 +27,6 @@ import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.codehaus.groovy.ast.Variable;
 
-import groovy.lang.groovydoc.Groovydoc;
 import net.prominic.groovyls.compiler.ast.ASTNodeVisitor;
 import net.prominic.groovyls.compiler.util.GroovyASTUtils;
 
@@ -69,8 +67,6 @@ public class GroovyNodeToStringUtils {
 			builder.append(superClass.getNameWithoutPackage());
 		}
 
-		addDocString(classNode, builder);
-
 		return builder.toString();
 	}
 
@@ -80,8 +76,6 @@ public class GroovyNodeToStringUtils {
 		builder.append("(");
 		builder.append(parametersToString(constructorNode.getParameters(), ast));
 		builder.append(")");
-
-		addDocString(constructorNode, builder);
 
 		return builder.toString();
 	}
@@ -115,8 +109,6 @@ public class GroovyNodeToStringUtils {
 		builder.append("(");
 		builder.append(parametersToString(methodNode.getParameters(), ast));
 		builder.append(")");
-
-		addDocString(methodNode, builder);
 
 		return builder.toString();
 	}
@@ -167,13 +159,4 @@ public class GroovyNodeToStringUtils {
 		return builder.toString();
 	}
 
-	public static void addDocString(AnnotatedNode node, StringBuilder builder) {
-
-		Groovydoc docstring = node.getGroovydoc();
-
-		if(docstring.isPresent()) {
-			builder.append("\n");
-			builder.append(docstring.getContent());
-		}
-	}
 }

--- a/src/test/java/net/prominic/groovyls/util/GroovyDocUtilsTests.java
+++ b/src/test/java/net/prominic/groovyls/util/GroovyDocUtilsTests.java
@@ -1,0 +1,214 @@
+package net.prominic.groovyls.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.CompileUnit;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.control.Phases;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import net.prominic.groovyls.compiler.control.GroovyLSCompilationUnit;
+import net.prominic.groovyls.config.CompilationUnitFactory;
+
+class GroovyDocUtilsTests {
+
+  private static final String PATH_WORKSPACE = "./build/test_workspace/";
+
+	@Test
+	void testDidRemoveSingleLineComment() {
+    String expected = "SomeMethod";
+		String docString = "/** " + expected + " */";
+		
+    String result = GroovyDocUtils.removeComment(docString);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidRemoveMultiLineComment() {
+    String expected = "SomeMethod";
+
+    StringBuilder docString = new StringBuilder();
+
+    docString.append("/**\n");
+    docString.append("* " + expected + "\n");
+    docString.append("*/");
+
+    String result = GroovyDocUtils.removeComment(docString.toString());
+
+		Assertions.assertEquals(expected + "\n", result.toString());
+	}
+
+  @Test
+	void testDidConvertParams() {
+    String text = "@param MyParam This is a test param.";
+    String expected = "- *param* **MyParam** - This is a test param.";
+
+    String result = GroovyDocUtils.convertParams(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidNotConvertParams() {
+    String text = "SomeText";
+    String expected = text;
+
+    String result = GroovyDocUtils.convertParams(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidConvertReturn() {
+    String text = "@return Some Value";
+    String expected = "- *return* - Some Value";
+
+    String result = GroovyDocUtils.convertReturn(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidNotConvertReturn() {
+    String text = "SomeText";
+    String expected = text;
+
+    String result = GroovyDocUtils.convertParams(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidRemoveTags() {
+    String text = "@see Some Value";
+    String expected = "";
+
+    String result = GroovyDocUtils.removeTags(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidNotRemoveTags() {
+    String text = "SomeText";
+    String expected = text;
+
+    String result = GroovyDocUtils.convertParams(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidConvertNewLines() {
+    String text = "\n";
+    String expected = "  " + text;
+
+    String result = GroovyDocUtils.convertNewLines(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidNotConvertNewLines() {
+    String text = "SomeText";
+    String expected = text;
+
+    String result = GroovyDocUtils.convertNewLines(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidConvertToMarkdown() {
+    
+    final String docString = "/**\n"
+    + "* Returns an Image object that can then be painted on the screen.\n"
+    + "* The url argument must specify an absolute <a href=\"#{@link}\">{@link URL}</a>. The name\n"
+    + "* argument is a specifier that is relative to the url argument.\n"
+    + "*\n"
+    + "* This method always returns immediately, whether or not the\n"
+    + "* image exists. When this applet attempts to draw the image on\n"
+    + "* the screen, the data will be loaded. The graphics primitives\n"
+    + "* that draw the image will incrementally paint on the screen.\n"
+    + "*\n"
+    + "* @param  url  an absolute URL giving the base location of the image\n"
+    + "* @param  name the location of the image, relative to the url argument\n"
+    + "* @return      the image at the specified URL\n"
+    + "* @see         Image\n"
+    + "*/";
+
+    final String expected = "Returns an Image object that can then be painted on the screen.  \n"
+	 + "The url argument must specify an absolute <a href=\"#{@link}\">{@link URL}</a>. The name  \n"
+	 + "argument is a specifier that is relative to the url argument.  \n  \n"
+	 + "This method always returns immediately, whether or not the  \n"
+	 + "image exists. When this applet attempts to draw the image on  \n"
+	 + "the screen, the data will be loaded. The graphics primitives  \n"
+	 + "that draw the image will incrementally paint on the screen.  \n  \n"
+	 + "- *param* **url** - an absolute URL giving the base location of the image  \n"
+	 + "- *param* **name** - the location of the image, relative to the url argument  \n"
+	 + "- *return* - the image at the specified URL  \n";
+
+		
+    String result = GroovyDocUtils.convertToMarkdown(docString);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidNotConvertToMarkdown() {
+    
+    String text = "Some Value";
+    String expected = text;
+
+		
+    String result = GroovyDocUtils.convertToMarkdown(text);
+
+		Assertions.assertEquals(expected, result);
+	}
+
+  @Test
+	void testDidAddDocString() {
+  
+    CompilationUnitFactory cf = new CompilationUnitFactory();
+
+    FileContentsTracker fileContentsTracker = new FileContentsTracker();
+
+    Path workspaceRoot = Paths.get(System.getProperty("user.dir")).resolve(PATH_WORKSPACE);
+
+    GroovyLSCompilationUnit cp = cf.create(workspaceRoot, fileContentsTracker);
+
+    StringBuilder funcDefinition = new StringBuilder();
+
+    funcDefinition.append("class MyClass {\n");
+    funcDefinition.append("  /** SomeFunction */\n");
+    funcDefinition.append("  def myFunction() {}\n");
+    funcDefinition.append("}");
+
+    cp.addSource("test.groovy", funcDefinition.toString());
+    cp.compile(Phases.SEMANTIC_ANALYSIS);
+    CompileUnit ast = cp.getAST();
+    ClassNode parent = ast.getClasses().get(0);
+    MethodNode child = parent.getMethods().get(0);
+
+    String result = GroovyDocUtils.getDocString(child);
+
+		Assertions.assertNotNull(result);
+	}
+
+  @Test
+	void testDidNotAddDocString() {
+
+    AnnotatedNode node = new AnnotatedNode();
+    String expected = null;
+
+    String docString = GroovyDocUtils.getDocString(node);
+
+		Assertions.assertEquals(expected, docString);
+	}
+
+}


### PR DESCRIPTION
Fixes #50

So I found how to turn on the GroovyDoc parsing feature of Groovy3.

~~I also made and quick and dirty modification to show it working. Just checkout this branch and type `./gradlew test --info`~~

~~You should see something like this~~

![image](https://user-images.githubusercontent.com/17090999/128601878-3a22349c-bef7-43ab-b920-0e6c490d29cb.png)

What was really weird, ~~I could not get a multiline GroovyDoc comment to work~~. I tried several variations, but nothing. 

So any/most AST Nodes should now have the `getGroovydoc` method. My eyes are kinda tired today, but tomorrow I hope to actually modify the hover provider and try and add some groovydoc to it! 🚀 

