### PR TITLE
Bump groovy to 4.0.0-rc-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDEA
+.idea
+
 # Eclipse
 .classpath
 .project

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories  {
 dependencies {
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0"
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.12.0"
-  implementation "org.codehaus.groovy:groovy-all:2.5.14"
+  implementation "org.apache.groovy:groovy:4.0.0-rc-2"
   implementation "com.google.code.gson:gson:2.8.7"
   implementation "io.github.classgraph:classgraph:4.8.108"
   testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"

--- a/src/main/java/net/prominic/groovyls/GroovyServices.java
+++ b/src/main/java/net/prominic/groovyls/GroovyServices.java
@@ -463,7 +463,7 @@ public class GroovyServices implements TextDocumentService, WorkspaceService, La
 		Map<URI, List<Diagnostic>> diagnosticsByFile = new HashMap<>();
 
 		@SuppressWarnings("unchecked")
-		List<Message> errors = collector.getErrors();
+		List<? extends Message> errors = collector.getErrors();
 		if (errors != null) {
 			errors.stream().filter((Object message) -> message instanceof SyntaxErrorMessage)
 					.forEach((Object message) -> {

--- a/src/main/java/net/prominic/groovyls/compiler/ast/ASTNodeVisitor.java
+++ b/src/main/java/net/prominic/groovyls/compiler/ast/ASTNodeVisitor.java
@@ -510,7 +510,7 @@ public class ASTNodeVisitor extends ClassCodeVisitorSupport {
 		}
 	}
 
-	protected void visitEmptyStatement(EmptyStatement node) {
+	public void visitEmptyStatement(EmptyStatement node) {
 		pushASTNode(node);
 		try {
 			super.visitEmptyStatement(node);

--- a/src/main/java/net/prominic/groovyls/compiler/control/GroovyLSCompilationUnit.java
+++ b/src/main/java/net/prominic/groovyls/compiler/control/GroovyLSCompilationUnit.java
@@ -19,19 +19,19 @@
 ////////////////////////////////////////////////////////////////////////////////
 package net.prominic.groovyls.compiler.control;
 
-import java.security.CodeSource;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import groovy.lang.GroovyClassLoader;
 import org.codehaus.groovy.ast.CompileUnit;
 import org.codehaus.groovy.ast.ModuleNode;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.tools.GroovyClass;
 
-import groovy.lang.GroovyClassLoader;
+import java.security.CodeSource;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class GroovyLSCompilationUnit extends CompilationUnit {
 
@@ -53,16 +53,10 @@ public class GroovyLSCompilationUnit extends CompilationUnit {
 			if (sourceUnit.getAST() != null) {
 				List<String> sourceUnitClassNames = sourceUnit.getAST().getClasses().stream()
 						.map(classNode -> classNode.getName()).collect(Collectors.toList());
+				final List<GroovyClass> generatedClasses = getClasses();
 				generatedClasses.removeIf(groovyClass -> sourceUnitClassNames.contains(groovyClass.getName()));
-				for (String className : sourceUnitClassNames) {
-					summariesByPublicClassName.remove(className);
-					classSourcesByPublicClassName.remove(className);
-				}
 			}
-
-			summariesBySourceName.remove(sourceUnit.getName());
 			sources.remove(sourceUnit.getName());
-			names.remove(sourceUnit.getName());
 		}
 		//keep existing modules from other source units
 		List<ModuleNode> modules = ast.getModules();


### PR DESCRIPTION
Groovy 4.0.0 GA will be released this month and it will be the recommended version to use, so it's better to develop LSP based on it.
/cc @paulk-asert